### PR TITLE
Update linter, fix lint issues, update .gitignore, and add more dart docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,14 @@ build/
 
 # Directory created by dartdoc
 doc/api/
+
+.vscode
+
+# IntelliJ
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# Mac
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -4,26 +4,23 @@
 
 This project aims to wrap the complete [Pdfium](https://pdfium.googlesource.com/pdfium/) API in dart, over FFI.
 
-# Example low level:
-
+# Low-level example:
 ```dart
 import 'dart:ffi';
 import 'dart:io';
 
 import 'package:ffi/ffi.dart';
-import 'package:pdfium_bindings/pdfium_bindings.dart';
-import 'package:path/path.dart' as path;
-import 'package:pdfium_bindings/src/utils.dart';
 import 'package:image/image.dart';
+import 'package:path/path.dart' as path;
+import 'package:pdfium_bindings/pdfium_bindings.dart';
 
 void main() {
-  //the dynamic library path  
- var stopwatch = Stopwatch()..start();
-  var libraryPath = path.join(Directory.current.path, 'pdfium.dll');
+  final stopwatch = Stopwatch()..start();
+  final libraryPath = path.join(Directory.current.path, 'pdfium.dll');
   final dylib = DynamicLibrary.open(libraryPath);
-  var pdfium = PDFiumBindings(dylib);
+  final pdfium = PDFiumBindings(dylib);
 
-  var allocate = calloc;
+  const allocate = calloc;
 
   final config = allocate<FPDF_LIBRARY_CONFIG>();
   config.ref.version = 2;
@@ -32,38 +29,38 @@ void main() {
   config.ref.m_v8EmbedderSlot = 0;
   pdfium.FPDF_InitLibraryWithConfig(config);
 
-  var filePathP = stringToNativeInt8('1417.pdf');
+  final filePathP = stringToNativeInt8('1417.pdf');
 
-  var doc = pdfium.FPDF_LoadDocument(filePathP, nullptr);
+  final doc = pdfium.FPDF_LoadDocument(filePathP, nullptr);
   if (doc == nullptr) {
-    var err = pdfium.FPDF_GetLastError();
+    final err = pdfium.FPDF_GetLastError();
     throw PdfiumException.fromErrorCode(err);
   }
 
-  var pageCount = pdfium.FPDF_GetPageCount(doc);
+  final pageCount = pdfium.FPDF_GetPageCount(doc);
   print('pageCount: $pageCount');
 
-  var page = pdfium.FPDF_LoadPage(doc, 0);
+  final page = pdfium.FPDF_LoadPage(doc, 0);
   if (page == nullptr) {
-    var err = pdfium.getLastErrorMessage();
+    final err = pdfium.getLastErrorMessage();
     pdfium.FPDF_CloseDocument(doc);
     throw PageException(message: err);
   }
 
-  var scale = 1;
-  var width = (pdfium.FPDF_GetPageWidth(page) * scale).round();
-  var height = (pdfium.FPDF_GetPageHeight(page) * scale).round();
+  const scale = 1;
+  final width = (pdfium.FPDF_GetPageWidth(page) * scale).round();
+  final height = (pdfium.FPDF_GetPageHeight(page) * scale).round();
 
   print('page Width: $width');
   print('page Height: $height');
 
   // var backgroundStr = "FFFFFFFF"; // as int 268435455
-  var background = 268435455;
-  var start_x = 0;
-  var size_x = width;
-  var start_y = 0;
-  var size_y = height;
-  var rotate = 0;
+  const background = 268435455;
+  const startX = 0;
+  final sizeX = width;
+  const startY = 0;
+  final sizeY = height;
+  const rotate = 0;
 
   // Create empty bitmap and render page onto it
   // The bitmap always uses 4 bytes per pixel. The first byte is always
@@ -71,17 +68,17 @@ void main() {
   // The byte order is BGRx (the last byte unused if no alpha channel) or
   // BGRA. flags FPDF_ANNOT | FPDF_LCD_TEXT
 
-  var bitmap = pdfium.FPDFBitmap_Create(width, height, 0);
+  final bitmap = pdfium.FPDFBitmap_Create(width, height, 0);
   pdfium.FPDFBitmap_FillRect(bitmap, 0, 0, width, height, background);
   pdfium.FPDF_RenderPageBitmap(
-      bitmap, page, start_x, start_y, size_x, size_y, rotate, 0);
+      bitmap, page, startX, startY, sizeX, sizeY, rotate, 0,);
   //  The pointer to the first byte of the bitmap buffer The data is in BGRA format
-  var pointer = pdfium.FPDFBitmap_GetBuffer(bitmap);
+  final pointer = pdfium.FPDFBitmap_GetBuffer(bitmap);
   //stride = width * 4 bytes per pixel BGRA
   //var stride = pdfium.FPDFBitmap_GetStride(bitmap);
   //print('stride $stride');
 
-  Image image = Image.fromBytes(
+  final Image image = Image.fromBytes(
       width: width,
       height: height,
       bytes: pointer.asTypedList(width * height * 4).buffer,
@@ -105,9 +102,11 @@ void main() {
 }
 
 ```
-# Example hi level:
+# High-level example:
 
 ```dart
+import 'package:pdfium_bindings/pdfium_bindings.dart';
+
 void main() {
   PdfiumWrap()
       .loadDocumentFromPath('1417.pdf')
@@ -118,20 +117,23 @@ void main() {
       .dispose();
 }
 ```
-# Example 2 hi level:
 
+# High-level example 2:
 ```dart
-import 'package:pdfium_bindings/pdfium_bindings.dart';
 import 'package:http/http.dart' as http;
+import 'package:pdfium_bindings/pdfium_bindings.dart';
 
 void main() async {
-  var pdfium = PdfiumWrap();
+  final pdfium = PdfiumWrap();
 
-  var resp = await http.get(Uri.parse(
-      'https://www.riodasostras.rj.gov.br/wp-content/uploads/2022/03/1426.pdf'));
-  var bytes = resp.bodyBytes;
+  final resp = await http.get(
+    Uri.parse(
+      'https://www.riodasostras.rj.gov.br/wp-content/uploads/2022/03/1426.pdf',
+    ),
+  );
+  final bytes = resp.bodyBytes;
 
- pdfium
+  pdfium
       .loadDocumentFromBytes(bytes)
       .loadPage(0)
       .savePageAsJpg('out.jpg', qualityJpg: 80)

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,7 @@
 # Defines a default set of lint rules enforced for
-# projects at Google. For details and rationale,
-# see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+# projects. For details and rationale,
+# see https://pub.dev/packages/lint.
+include: package:lint/package.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.
@@ -10,5 +10,5 @@ include: package:pedantic/analysis_options.yaml
 #     - camel_case_types
 
 analyzer:
-#   exclude:
-#     - path/to/excluded/files/**
+  exclude:
+    - lib/src/pdfium_bindings.dart

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,7 +7,7 @@ include: package:lint/package.yaml
 # Uncomment to specify additional rules.
 # linter:
 #   rules:
-#     - camel_case_types
+#     - public_member_api_docs
 
 analyzer:
   exclude:

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,21 +1,20 @@
+// ignore_for_file: avoid_print
+
 import 'dart:ffi';
 import 'dart:io';
 
 import 'package:ffi/ffi.dart';
-import 'package:pdfium_bindings/pdfium_bindings.dart';
-import 'package:path/path.dart' as path;
-import 'package:pdfium_bindings/src/utils.dart';
 import 'package:image/image.dart';
+import 'package:path/path.dart' as path;
+import 'package:pdfium_bindings/pdfium_bindings.dart';
 
 void main() {
-  //var libraryPath = 'C:\MyDartProjects\pdfium\pdfium-binaries\win\bin\pdfium.dll';
-  // C:\Program Files (x86)\Microsoft Visual Studio\2019\Community>dumpbin /dependents C:\MyDartProjects\pdfium\pdfium-binaries\win\bin\pdfium.dll
-  var stopwatch = Stopwatch()..start();
-  var libraryPath = path.join(Directory.current.path, 'pdfium.dll');
+  final stopwatch = Stopwatch()..start();
+  final libraryPath = path.join(Directory.current.path, 'pdfium.dll');
   final dylib = DynamicLibrary.open(libraryPath);
-  var pdfium = PDFiumBindings(dylib);
+  final pdfium = PDFiumBindings(dylib);
 
-  var allocate = calloc;
+  const allocate = calloc;
 
   final config = allocate<FPDF_LIBRARY_CONFIG>();
   config.ref.version = 2;
@@ -24,38 +23,38 @@ void main() {
   config.ref.m_v8EmbedderSlot = 0;
   pdfium.FPDF_InitLibraryWithConfig(config);
 
-  var filePathP = stringToNativeInt8('1417.pdf');
+  final filePathP = stringToNativeInt8('1417.pdf');
 
-  var doc = pdfium.FPDF_LoadDocument(filePathP, nullptr);
+  final doc = pdfium.FPDF_LoadDocument(filePathP, nullptr);
   if (doc == nullptr) {
-    var err = pdfium.FPDF_GetLastError();
+    final err = pdfium.FPDF_GetLastError();
     throw PdfiumException.fromErrorCode(err);
   }
 
-  var pageCount = pdfium.FPDF_GetPageCount(doc);
+  final pageCount = pdfium.FPDF_GetPageCount(doc);
   print('pageCount: $pageCount');
 
-  var page = pdfium.FPDF_LoadPage(doc, 0);
+  final page = pdfium.FPDF_LoadPage(doc, 0);
   if (page == nullptr) {
-    var err = pdfium.getLastErrorMessage();
+    final err = pdfium.getLastErrorMessage();
     pdfium.FPDF_CloseDocument(doc);
     throw PageException(message: err);
   }
 
-  var scale = 1;
-  var width = (pdfium.FPDF_GetPageWidth(page) * scale).round();
-  var height = (pdfium.FPDF_GetPageHeight(page) * scale).round();
+  const scale = 1;
+  final width = (pdfium.FPDF_GetPageWidth(page) * scale).round();
+  final height = (pdfium.FPDF_GetPageHeight(page) * scale).round();
 
   print('page Width: $width');
   print('page Height: $height');
 
   // var backgroundStr = "FFFFFFFF"; // as int 268435455
-  var background = 268435455;
-  var start_x = 0;
-  var size_x = width;
-  var start_y = 0;
-  var size_y = height;
-  var rotate = 0;
+  const background = 268435455;
+  const startX = 0;
+  final sizeX = width;
+  const startY = 0;
+  final sizeY = height;
+  const rotate = 0;
 
   // Create empty bitmap and render page onto it
   // The bitmap always uses 4 bytes per pixel. The first byte is always
@@ -63,17 +62,17 @@ void main() {
   // The byte order is BGRx (the last byte unused if no alpha channel) or
   // BGRA. flags FPDF_ANNOT | FPDF_LCD_TEXT
 
-  var bitmap = pdfium.FPDFBitmap_Create(width, height, 0);
+  final bitmap = pdfium.FPDFBitmap_Create(width, height, 0);
   pdfium.FPDFBitmap_FillRect(bitmap, 0, 0, width, height, background);
   pdfium.FPDF_RenderPageBitmap(
-      bitmap, page, start_x, start_y, size_x, size_y, rotate, 0);
+      bitmap, page, startX, startY, sizeX, sizeY, rotate, 0,);
   //  The pointer to the first byte of the bitmap buffer The data is in BGRA format
-  var pointer = pdfium.FPDFBitmap_GetBuffer(bitmap);
+  final pointer = pdfium.FPDFBitmap_GetBuffer(bitmap);
   //stride = width * 4 bytes per pixel BGRA
   //var stride = pdfium.FPDFBitmap_GetStride(bitmap);
   //print('stride $stride');
 
-  Image image = Image.fromBytes(
+  final Image image = Image.fromBytes(
       width: width,
       height: height,
       bytes: pointer.asTypedList(width * height * 4).buffer,

--- a/example/example2.dart
+++ b/example/example2.dart
@@ -13,12 +13,12 @@ void main() {
   pdfium!.dispose();
 }
 
-var count = 0;
+int count = 0;
 void loop() {
   pdfium!.closeDocument();
   pdfium!.loadDocumentFromPath('1417.pdf');
 
-  var pageCount = pdfium!.getPageCount();
+  final pageCount = pdfium!.getPageCount();
   for (var i = 0; i < pageCount; i++) {
     pdfium!
         .loadPage(i)

--- a/example/example3.dart
+++ b/example/example3.dart
@@ -1,12 +1,15 @@
-import 'package:pdfium_bindings/pdfium_bindings.dart';
 import 'package:http/http.dart' as http;
+import 'package:pdfium_bindings/pdfium_bindings.dart';
 
 void main() async {
-  var pdfium = PdfiumWrap();
+  final pdfium = PdfiumWrap();
 
-  var resp = await http.get(Uri.parse(
-      'https://www.riodasostras.rj.gov.br/wp-content/uploads/2022/03/1426.pdf'));
-  var bytes = resp.bodyBytes;
+  final resp = await http.get(
+    Uri.parse(
+      'https://www.riodasostras.rj.gov.br/wp-content/uploads/2022/03/1426.pdf',
+    ),
+  );
+  final bytes = resp.bodyBytes;
 
   pdfium
       .loadDocumentFromBytes(bytes)

--- a/lib/pdfium_bindings.dart
+++ b/lib/pdfium_bindings.dart
@@ -1,7 +1,7 @@
 library pdfium_bindings;
 
-export 'src/pdfium_bindings.dart';
-export 'src/extensions.dart';
-export 'src/utils.dart';
 export 'src/exceptions.dart';
+export 'src/extensions.dart';
+export 'src/pdfium_bindings.dart';
 export 'src/pdfium_wrap.dart';
+export 'src/utils.dart';

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -1,8 +1,16 @@
+/// An exception class that's thrown when a pdfium operation is unable to be
+/// done correctly.
 class PdfiumException implements Exception {
+  /// Error code of the exception
   int? errorCode;
+
+  /// A message describing the error.
   String? message = '';
+
+  /// Default constructor of PdfiumException
   PdfiumException({this.message});
 
+  /// Factory constructor to create a FileException with an error code
   factory PdfiumException.fromErrorCode(int errorCode) {
     final e = FileException();
     e.errorCode = errorCode;

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -4,13 +4,14 @@ class PdfiumException implements Exception {
   PdfiumException({this.message});
 
   factory PdfiumException.fromErrorCode(int errorCode) {
-    var e = FileException();
+    final e = FileException();
     e.errorCode = errorCode;
     return e;
   }
 
   @override
   String toString() {
+    // ignore: no_runtimetype_tostring
     return '$runtimeType: $errorCode | $message';
   }
 }

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -4,28 +4,28 @@ extension LastError on PDFiumBindings {
   String getLastErrorMessage() {
     switch (FPDF_GetLastError()) {
       case FPDF_ERR_SUCCESS:
-        return ('Success');
+        return 'Success';
 
       case FPDF_ERR_UNKNOWN:
-        return ('Unknown error');
+        return 'Unknown error';
 
       case FPDF_ERR_FILE:
-        return ('File not found or could not be opened');
+        return 'File not found or could not be opened';
 
       case FPDF_ERR_FORMAT:
-        return ('File not in PDF format or corrupted');
+        return 'File not in PDF format or corrupted';
 
       case FPDF_ERR_PASSWORD:
-        return ('Password required or incorrect password');
+        return 'Password required or incorrect password';
 
       case FPDF_ERR_SECURITY:
-        return ('Unsupported security scheme');
+        return 'Unsupported security scheme';
 
       case FPDF_ERR_PAGE:
-        return ('Page not found or content error');
+        return 'Page not found or content error';
 
       default:
-        return ('Unknown error ');
+        return 'Unknown error ';
     }
   }
 }

--- a/lib/src/pdfium_wrap.dart
+++ b/lib/src/pdfium_wrap.dart
@@ -3,10 +3,9 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
-import 'package:pdfium_bindings/pdfium_bindings.dart';
-import 'package:path/path.dart' as path;
-import 'package:pdfium_bindings/src/utils.dart';
 import 'package:image/image.dart';
+import 'package:path/path.dart' as path;
+import 'package:pdfium_bindings/pdfium_bindings.dart';
 
 class PdfiumWrap {
   late PDFiumBindings pdfium;
@@ -46,11 +45,11 @@ class PdfiumWrap {
   }
 
   PdfiumWrap loadDocumentFromPath(String path, {String? password}) {
-    var filePathP = stringToNativeInt8(path);
+    final filePathP = stringToNativeInt8(path);
     _document = pdfium.FPDF_LoadDocument(
-        filePathP, password != null ? stringToNativeInt8(password) : nullptr);
+        filePathP, password != null ? stringToNativeInt8(password) : nullptr,);
     if (_document == nullptr) {
-      var err = pdfium.FPDF_GetLastError();
+      final err = pdfium.FPDF_GetLastError();
       throw PdfiumException.fromErrorCode(err);
     }
     return this;
@@ -66,10 +65,10 @@ class PdfiumWrap {
     _document = pdfium.FPDF_LoadMemDocument64(
         frameData.cast<Void>(),
         bytes.length,
-        password != null ? stringToNativeInt8(password) : nullptr);
+        password != null ? stringToNativeInt8(password) : nullptr,);
 
     if (_document == nullptr) {
-      var err = pdfium.FPDF_GetLastError();
+      final err = pdfium.FPDF_GetLastError();
       throw PdfiumException.fromErrorCode(err);
     }
     return this;
@@ -81,7 +80,7 @@ class PdfiumWrap {
     }
     _page = pdfium.FPDF_LoadPage(_document!, index);
     if (_page == nullptr) {
-      var err = pdfium.getLastErrorMessage();
+      final err = pdfium.getLastErrorMessage();
       throw PageException(message: err);
     }
     return this;
@@ -114,17 +113,17 @@ class PdfiumWrap {
   /// The byte order is BGRx (the last byte unused if no alpha channel) or
   /// BGRA. flags FPDF_ANNOT | FPDF_LCD_TEXT
   Uint8List renderPageAsBytes(int width, int height,
-      {int backgroundColor = 268435455, int rotate = 0, int flags = 0}) {
+      {int backgroundColor = 268435455, int rotate = 0, int flags = 0,}) {
     if (_page == nullptr) {
       throw PdfiumException(message: 'Page not load');
     }
     // var backgroundStr = "FFFFFFFF"; // as int 268435455
-    var w = width;
-    var h = height;
-    var start_x = 0;
-    var size_x = w;
-    var start_y = 0;
-    var size_y = h;
+    final w = width;
+    final h = height;
+    const startX = 0;
+    final sizeX = w;
+    const startY = 0;
+    final sizeY = h;
 
     // Create empty bitmap and render page onto it
     // The bitmap always uses 4 bytes per pixel. The first byte is always
@@ -135,13 +134,13 @@ class PdfiumWrap {
     bitmap = pdfium.FPDFBitmap_Create(w, h, 0);
     pdfium.FPDFBitmap_FillRect(bitmap!, 0, 0, w, h, backgroundColor);
     pdfium.FPDF_RenderPageBitmap(
-        bitmap!, _page!, start_x, start_y, size_x, size_y, rotate, flags);
+        bitmap!, _page!, startX, startY, sizeX, sizeY, rotate, flags,);
     //  The pointer to the first byte of the bitmap buffer The data is in BGRA format
     buffer = pdfium.FPDFBitmap_GetBuffer(bitmap!);
     //stride = width * 4 bytes per pixel BGRA
     //var stride = pdfium.FPDFBitmap_GetStride(bitmap);
     //print('stride $stride');
-    var list = buffer!.asTypedList(w * h * 4);
+    final list = buffer!.asTypedList(w * h * 4);
 
     return list;
   }
@@ -154,18 +153,18 @@ class PdfiumWrap {
       int rotate = 0,
       int flags = 0,
       bool flush = false,
-      int pngLevel = 6}) {
+      int pngLevel = 6,}) {
     if (_page == nullptr) {
       throw PdfiumException(message: 'Page not load');
     }
     // var backgroundStr = "FFFFFFFF"; // as int 268435455
-    var w = ((width ?? getPageWidth()) * scale).round();
-    var h = ((height ?? getPageHeight()) * scale).round();
+    final w = ((width ?? getPageWidth()) * scale).round();
+    final h = ((height ?? getPageHeight()) * scale).round();
 
-    var bytes = renderPageAsBytes(w, h,
-        backgroundColor: backgroundColor, rotate: rotate, flags: flags);
+    final bytes = renderPageAsBytes(w, h,
+        backgroundColor: backgroundColor, rotate: rotate, flags: flags,);
 
-    Image image = Image.fromBytes(
+    final Image image = Image.fromBytes(
       width: w,
       height: h,
       bytes: bytes.buffer,
@@ -187,18 +186,18 @@ class PdfiumWrap {
       int rotate = 0,
       int flags = 0,
       bool flush = false,
-      int qualityJpg = 100}) {
+      int qualityJpg = 100,}) {
     if (_page == nullptr) {
       throw PdfiumException(message: 'Page not load');
     }
     // var backgroundStr = "FFFFFFFF"; // as int 268435455
-    var w = ((width ?? getPageWidth()) * scale).round();
-    var h = ((height ?? getPageHeight()) * scale).round();
+    final w = ((width ?? getPageWidth()) * scale).round();
+    final h = ((height ?? getPageHeight()) * scale).round();
 
-    var bytes = renderPageAsBytes(w, h,
-        backgroundColor: backgroundColor, rotate: rotate, flags: flags);
+    final bytes = renderPageAsBytes(w, h,
+        backgroundColor: backgroundColor, rotate: rotate, flags: flags,);
 
-    Image image = Image.fromBytes(
+    final Image image = Image.fromBytes(
       width: w,
       height: h,
       bytes: bytes.buffer,

--- a/lib/src/pdfium_wrap.dart
+++ b/lib/src/pdfium_wrap.dart
@@ -7,8 +7,11 @@ import 'package:image/image.dart';
 import 'package:path/path.dart' as path;
 import 'package:pdfium_bindings/pdfium_bindings.dart';
 
+/// Wrapper class to abstract the PDFium logic
 class PdfiumWrap {
+  /// Bindings to PDFium
   late PDFiumBindings pdfium;
+  /// PDFium configuration
   late Pointer<FPDF_LIBRARY_CONFIG> config;
   final Allocator allocator;
   Pointer<fpdf_document_t__>? _document;
@@ -16,6 +19,7 @@ class PdfiumWrap {
   Pointer<Uint8>? buffer;
   Pointer<fpdf_bitmap_t__>? bitmap;
 
+  /// Default constructor to use the class
   PdfiumWrap({String? libraryPath, this.allocator = calloc}) {
     //for windows
     var libPath = path.join(Directory.current.path, 'pdfium.dll');
@@ -44,6 +48,11 @@ class PdfiumWrap {
     pdfium.FPDF_InitLibraryWithConfig(config);
   }
 
+  /// Loads a document from [path], and if necessary, a [password] can be
+  /// specified.
+  ///
+  /// Throws an [PdfiumException] if no document is loaded.
+  /// Returns a instance of [PdfiumWrap]
   PdfiumWrap loadDocumentFromPath(String path, {String? password}) {
     final filePathP = stringToNativeInt8(path);
     _document = pdfium.FPDF_LoadDocument(
@@ -55,6 +64,11 @@ class PdfiumWrap {
     return this;
   }
 
+  /// Loads a document from [bytes], and if necessary, a [password] can be
+  /// specified.
+  ///
+  /// Throws an [PdfiumException] if the document is null.
+  /// Returns a instance of [PdfiumWrap]
   PdfiumWrap loadDocumentFromBytes(Uint8List bytes, {String? password}) {
     // Allocate a pointer large enough.
     final frameData = allocator<Uint8>(bytes.length);
@@ -74,6 +88,11 @@ class PdfiumWrap {
     return this;
   }
 
+  /// Loads a page from a document loaded
+  ///
+  /// Throws an [PdfiumException] if the no document is loaded, and a
+  /// [PageException] if the page being attempted to load does not exist.
+  /// Returns a instance of [PdfiumWrap]
   PdfiumWrap loadPage(int index) {
     if (_document == nullptr) {
       throw PdfiumException(message: 'Document not load');
@@ -86,6 +105,9 @@ class PdfiumWrap {
     return this;
   }
 
+  /// Returns the number of pages of the loaded document.
+  ///
+  /// Throws an [PdfiumException] if the no document is loaded
   int getPageCount() {
     if (_document == nullptr) {
       throw PdfiumException(message: 'Document not load');
@@ -93,6 +115,9 @@ class PdfiumWrap {
     return pdfium.FPDF_GetPageCount(_document!);
   }
 
+  /// Returns the width of the loaded page.
+  ///
+  /// Throws an [PdfiumException] if no page is loaded
   double getPageWidth() {
     if (_page == nullptr) {
       throw PdfiumException(message: 'Page not load');
@@ -100,6 +125,9 @@ class PdfiumWrap {
     return pdfium.FPDF_GetPageWidth(_page!);
   }
 
+  /// Returns the height of the loaded page.
+  ///
+  /// Throws an [PdfiumException] if no page is loaded
   double getPageHeight() {
     if (_page == nullptr) {
       throw PdfiumException(message: 'Page not load');
@@ -145,6 +173,10 @@ class PdfiumWrap {
     return list;
   }
 
+  /// Saves the loaded page as png image
+  ///
+  /// Throws an [PdfiumException] if no page is loaded.
+  /// Returns a instance of [PdfiumWrap]
   PdfiumWrap savePageAsPng(String outPath,
       {int? width,
       int? height,
@@ -178,6 +210,10 @@ class PdfiumWrap {
     return this;
   }
 
+  /// Saves the loaded page as jpg image
+  ///
+  /// Throws an [PdfiumException] if no page is loaded.
+  /// Returns a instance of [PdfiumWrap]
   PdfiumWrap savePageAsJpg(String outPath,
       {int? width,
       int? height,
@@ -211,6 +247,7 @@ class PdfiumWrap {
     return this;
   }
 
+  /// Closes the page if it was open. Returns a instance of [PdfiumWrap]
   PdfiumWrap closePage() {
     if (_page != null && _page != nullptr) {
       pdfium.FPDF_ClosePage(_page!);
@@ -222,6 +259,7 @@ class PdfiumWrap {
     return this;
   }
 
+  /// Closes the document if it was open. Returns a instance of [PdfiumWrap]
   PdfiumWrap closeDocument() {
     if (_document != null && _document != nullptr) {
       pdfium.FPDF_CloseDocument(_document!);
@@ -229,6 +267,8 @@ class PdfiumWrap {
     return this;
   }
 
+  /// Destroys and releases the memory allocated for the library when is not
+  /// longer used
   void dispose() {
     // closePage();
     // closeDocument();

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -33,23 +33,23 @@ Pointer<Int8> stringToNativeInt8(String str, {Allocator allocator = calloc}) {
 }
 
 String nativeInt8ToString(Pointer<Int8> pointer, {bool allowMalformed = true}) {
-  var ptrName = pointer.cast<Utf8>();
+  final ptrName = pointer.cast<Utf8>();
   final ptrNameCodeUnits = pointer.cast<Uint8>();
-  var list = ptrNameCodeUnits.asTypedList(ptrName.length);
+  final list = ptrNameCodeUnits.asTypedList(ptrName.length);
   return utf8.decode(list, allowMalformed: allowMalformed);
 }
 
 Uint8List nativeInt8ToCodeUnits(Pointer<Int8> pointer) {
-  var ptrName = pointer.cast<Utf8>();
+  final ptrName = pointer.cast<Utf8>();
   final ptrNameCodeUnits = pointer.cast<Uint8>();
-  var list = ptrNameCodeUnits.asTypedList(ptrName.length);
+  final list = ptrNameCodeUnits.asTypedList(ptrName.length);
   return list;
 }
 
 Uint8List nativeInt8ToUint8List(Pointer<Int8> pointer) {
-  var ptrName = pointer.cast<Utf8>();
+  final ptrName = pointer.cast<Utf8>();
   final ptrNameCodeUnits = pointer.cast<Uint8>();
-  var list = ptrNameCodeUnits.asTypedList(ptrName.length);
+  final list = ptrNameCodeUnits.asTypedList(ptrName.length);
   return list;
 }
 
@@ -59,16 +59,15 @@ Uint8List nativeInt8ToUint8List(Pointer<Int8> pointer) {
 /// Unix reserved filenames (. and ..)
 /// Trailing periods and spaces (for Windows)
 /// Windows reserved filenames (CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9)
-String sanitizeFilename(String input, [replacement = '_']) {
-  var illegalRe = RegExp(r'[\/\?<>\\:\*\|"]', multiLine: true);
-  var controlRe = RegExp(r'[\x00-\x1f\x80-\x9f]', multiLine: true);
-  var reservedRe = RegExp(r'^\.+$');
-  var windowsReservedRe = RegExp(
-      r'^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$',
-      caseSensitive: false);
+String sanitizeFilename(String input, [String replacement = '_']) {
+  final illegalRe = RegExp(r'[\/\?<>\\:\*\|"]', multiLine: true);
+  final controlRe = RegExp(r'[\x00-\x1f\x80-\x9f]', multiLine: true);
+  final reservedRe = RegExp(r'^\.+$');
+  final windowsReservedRe = RegExp(
+    r'^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$',
+    caseSensitive: false,
+  );
   // var windowsTrailingRe = RegExp(r'[\. ]+$');
-
-  //╟O caractere invalido
 
   var sanitized = input
       .replaceAll('�', replacement)
@@ -92,9 +91,9 @@ String sanitizeFilename(String input, [replacement = '_']) {
 
 bool isUft8MalformedStringPointer(Pointer<Int8> pointer) {
   try {
-    var ptrName = pointer.cast<Utf8>();
+    final ptrName = pointer.cast<Utf8>();
     final ptrNameCodeUnits = pointer.cast<Uint8>();
-    var list = ptrNameCodeUnits.asTypedList(ptrName.length);
+    final list = ptrNameCodeUnits.asTypedList(ptrName.length);
     utf8.decode(list);
     return false;
   } catch (e) {
@@ -111,11 +110,11 @@ Uint8List stringToUint8ListTo(String str) {
 }
 
 /// combine/concatenate two Uint8List
-Uint8List concatUint8List(List<Uint8List> lists) {
-  var bytesBuilder = BytesBuilder();
-  lists.forEach((l) {
+Uint8List concatenateUint8List(List<Uint8List> lists) {
+  final bytesBuilder = BytesBuilder();
+  for (final l in lists) {
     bytesBuilder.add(l);
-  });
+  }
   return bytesBuilder.toBytes();
 }
 
@@ -125,8 +124,10 @@ Pointer<Void> intToNativeVoid(int number) {
   return ptr.cast();
 }
 
-Pointer<Int8> uint8ListToPointerInt8(Uint8List units,
-    {Allocator allocator = calloc}) {
+Pointer<Int8> uint8ListToPointerInt8(
+  Uint8List units, {
+  Allocator allocator = calloc,
+}) {
   final pointer = allocator<Uint8>(units.length + 1); //blob
   final nativeString = pointer.asTypedList(units.length + 1); //blobBytes
   nativeString.setAll(0, units);
@@ -134,11 +135,13 @@ Pointer<Int8> uint8ListToPointerInt8(Uint8List units,
   return pointer.cast();
 }
 
-Future writeAndFlush(IOSink sink, object) {
-  return sink.addStream((StreamController<List<int>>(sync: true)
-        ..add(utf8.encode(object.toString()))
-        ..close())
-      .stream);
+Future writeAndFlush(IOSink sink, Object object) {
+  return sink.addStream(
+    (StreamController<List<int>>(sync: true)
+          ..add(utf8.encode(object.toString()))
+          ..close())
+        .stream,
+  );
 }
 
 extension Uint8ListBlobConversion on Uint8List {
@@ -159,7 +162,7 @@ num pointsToPixels(num points, num ppi) {
 /// [Utf8] implements conversion between Dart strings and null-terminated
 /// Utf8-encoded "char*" strings in C.
 ///
-/// [Utf8] is respresented as a struct so that `Pointer<Utf8>` can be used in
+/// [Utf8] is represented as a Struct so that `Pointer<Utf8>` can be used in
 /// native function signatures.
 //
 // TODO(https://github.com/dart-lang/ffi/issues/4): No need to use
@@ -206,5 +209,4 @@ class Utf8 extends Struct {
 
   String toString() => fromUtf8(addressOf);
 }
-
- */
+*/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,4 +15,5 @@ dev_dependencies:
   build_runner: ^2.1.2
   ffigen: any #^2.4.2
   http: any
+  lint: ^2.0.0
 #dart run ffigen --config ffigen.yaml


### PR DESCRIPTION
This PR includes the following updates to the library:

- Migrated from a deprecated linter to an updated one available at https://pub.dev/packages/lint.
- Fixed all the lint issues found with the new linter in both the library and its examples, including ignoring the autogenerated code.
- Added new files to the .gitignore to ignore them.
- Added more dart docs to improve the clarity of the code.
